### PR TITLE
Add cursor column assertion

### DIFF
--- a/src/main/java/org/fest/assertions/api/android/database/AbstractCursorAssert.java
+++ b/src/main/java/org/fest/assertions/api/android/database/AbstractCursorAssert.java
@@ -23,13 +23,9 @@ public abstract class AbstractCursorAssert<S extends AbstractCursorAssert<S, A>,
 
   public S hasColumn(String columnName) {
     isNotNull();
-    if (actual.isBeforeFirst() || actual.isAfterLast()) {
-      actual.moveToFirst();
-    }
-    int actualColumnIndex = actual.getColumnIndex(columnName);
-    assertThat(actualColumnIndex) //
-        .overridingErrorMessage("Expected to have column <%s> but has not.", columnName) //
-        .isNotNegative();
+    assertThat(actual.getColumnNames()) //
+        .overridingErrorMessage("Expected to have column <%s> but did not.", columnName) //
+        .contains(columnName);
     return myself;
   }
 


### PR DESCRIPTION
I’m still not sure about this assertion goodness because of it’s side-effect (moving a cursor) :-?
