### PR TITLE
Fixed java.util.MissingFormatArgumentException

### DIFF
--- a/src/main/java/org/fest/assertions/api/android/support/v4/app/FragmentManagerAssert.java
+++ b/src/main/java/org/fest/assertions/api/android/support/v4/app/FragmentManagerAssert.java
@@ -15,7 +15,7 @@ public class FragmentManagerAssert extends AbstractAssert<FragmentManagerAssert,
   public FragmentManagerAssert hasFragmentWithId(int id) {
     isNotNull();
     assertThat(actual.findFragmentById(id)) //
-        .overridingErrorMessage("Expected fragment with ID <%s> but was not found.") //
+        .overridingErrorMessage("Expected fragment with ID <%d> but was not found.", id) //
         .isNotNull();
     return this;
   }
@@ -23,7 +23,7 @@ public class FragmentManagerAssert extends AbstractAssert<FragmentManagerAssert,
   public FragmentManagerAssert hasFragmentWithTag(String tag) {
     isNotNull();
     assertThat(actual.findFragmentByTag(tag)) //
-        .overridingErrorMessage("Expected fragment with tag <%s> but was not found.") //
+        .overridingErrorMessage("Expected fragment with tag <%s> but was not found.", tag) //
         .isNotNull();
     return this;
   }


### PR DESCRIPTION
There were some arguments missing which caused an exception at runtime
