### PR TITLE
Revert "Merge pull request #18 from ming13/android-textutils"

### DIFF
--- a/src/main/java/org/fest/assertions/api/android/Utils.java
+++ b/src/main/java/org/fest/assertions/api/android/Utils.java
@@ -1,0 +1,20 @@
+package org.fest.assertions.api.android;
+
+import java.util.List;
+
+public final class Utils {
+  public static String join(List<String> parts) {
+    StringBuilder builder = new StringBuilder();
+    for (String part : parts) {
+      if (builder.length() > 0) {
+        builder.append(", ");
+      }
+      builder.append(part);
+    }
+    return builder.toString();
+  }
+
+  private Utils() {
+    // No instances.
+  }
+}

--- a/src/main/java/org/fest/assertions/api/android/app/ActionBarAssert.java
+++ b/src/main/java/org/fest/assertions/api/android/app/ActionBarAssert.java
@@ -1,7 +1,7 @@
 package org.fest.assertions.api.android.app;
 
 import android.app.ActionBar;
-import android.text.TextUtils;
+import org.fest.assertions.api.android.Utils;
 import java.util.ArrayList;
 import java.util.List;
 import org.fest.assertions.api.AbstractAssert;
@@ -153,6 +153,6 @@ public class ActionBarAssert extends AbstractAssert<ActionBarAssert, ActionBar> 
     if ((options & DISPLAY_USE_LOGO) != 0) {
       parts.add("useLogo");
     }
-    return TextUtils.join(", ", parts);
+    return Utils.join(parts);
   }
 }

--- a/src/main/java/org/fest/assertions/api/android/app/NotificationAssert.java
+++ b/src/main/java/org/fest/assertions/api/android/app/NotificationAssert.java
@@ -3,7 +3,7 @@ package org.fest.assertions.api.android.app;
 import android.app.Notification;
 import android.app.PendingIntent;
 import android.graphics.Bitmap;
-import android.text.TextUtils;
+import org.fest.assertions.api.android.Utils;
 import java.util.ArrayList;
 import java.util.List;
 import org.fest.assertions.api.AbstractAssert;
@@ -188,7 +188,7 @@ public class NotificationAssert extends AbstractAssert<NotificationAssert, Notif
     if ((flags & FLAG_HIGH_PRIORITY) != 0) {
       parts.add("highPriority");
     }
-    return TextUtils.join(", ", parts);
+    return Utils.join(parts);
   }
 
   private static String priorityToString(int priority) {

--- a/src/main/java/org/fest/assertions/api/android/graphics/AbstractPaintAssert.java
+++ b/src/main/java/org/fest/assertions/api/android/graphics/AbstractPaintAssert.java
@@ -7,7 +7,7 @@ import android.graphics.PathEffect;
 import android.graphics.Rasterizer;
 import android.graphics.Shader;
 import android.graphics.Typeface;
-import android.text.TextUtils;
+import org.fest.assertions.api.android.Utils;
 import java.util.ArrayList;
 import java.util.List;
 import org.fest.assertions.api.AbstractAssert;
@@ -357,6 +357,6 @@ public abstract class AbstractPaintAssert<S extends AbstractPaintAssert<S, A>, A
     if ((flags & UNDERLINE_TEXT_FLAG) != 0) {
       parts.add("underline");
     }
-    return TextUtils.join(", ", parts);
+    return Utils.join(parts);
   }
 }

--- a/src/main/java/org/fest/assertions/api/android/preference/RingtonePreferenceAssert.java
+++ b/src/main/java/org/fest/assertions/api/android/preference/RingtonePreferenceAssert.java
@@ -2,9 +2,9 @@
 package org.fest.assertions.api.android.preference;
 
 import android.preference.RingtonePreference;
-import android.text.TextUtils;
 import java.util.ArrayList;
 import java.util.List;
+import org.fest.assertions.api.android.Utils;
 
 import static android.media.RingtoneManager.TYPE_ALARM;
 import static android.media.RingtoneManager.TYPE_NOTIFICATION;
@@ -71,6 +71,6 @@ public class RingtonePreferenceAssert
     if ((type & TYPE_RINGTONE) != 0) {
       parts.add("ringtone");
     }
-    return TextUtils.join(", ", parts);
+    return Utils.join(parts);
   }
 }

--- a/src/main/java/org/fest/assertions/api/android/view/animation/GridLayoutAnimationControllerAssert.java
+++ b/src/main/java/org/fest/assertions/api/android/view/animation/GridLayoutAnimationControllerAssert.java
@@ -1,8 +1,8 @@
 // Copyright 2013 Square, Inc.
 package org.fest.assertions.api.android.view.animation;
 
-import android.text.TextUtils;
 import android.view.animation.GridLayoutAnimationController;
+import org.fest.assertions.api.android.Utils;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,7 +74,7 @@ public class GridLayoutAnimationControllerAssert extends
     } else {
       parts.add("topToBottom");
     }
-    return TextUtils.join(", ", parts);
+    return Utils.join(parts);
   }
 
   private static String directionPriorityToString(int priority) {

--- a/src/main/java/org/fest/assertions/api/android/widget/AbstractLinearLayoutAssert.java
+++ b/src/main/java/org/fest/assertions/api/android/widget/AbstractLinearLayoutAssert.java
@@ -1,7 +1,7 @@
 package org.fest.assertions.api.android.widget;
 
-import android.text.TextUtils;
 import android.widget.LinearLayout;
+import org.fest.assertions.api.android.Utils;
 import java.util.ArrayList;
 import java.util.List;
 import org.fest.assertions.api.android.view.AbstractViewGroupAssert;
@@ -112,7 +112,7 @@ public abstract class AbstractLinearLayoutAssert<S extends AbstractLinearLayoutA
     if ((dividers & SHOW_DIVIDER_END) != 0) {
       parts.add("end");
     }
-    return TextUtils.join(", ", parts);
+    return Utils.join(parts);
   }
 
   private static String orientationToString(int orientation) {


### PR DESCRIPTION
Despite that fact that every method in the library calls into Android, we don't actually want to rely on an Android implementation for any behavior. Theoretically the user could be mocking the methods or providing their own subclasses which return actual values.

Refs #18.

This reverts commit fd1eed5e9e643462a249a5234d91ace2507f53e0, reversing changes made to e03b6dcf1d02fc549c1e62e4e41286ff71fa1252.
