### PR TITLE
Add IntentAssert.hasFlags()

### DIFF
--- a/src/main/java/org/fest/assertions/api/android/content/IntentAssert.java
+++ b/src/main/java/org/fest/assertions/api/android/content/IntentAssert.java
@@ -2,6 +2,33 @@ package org.fest.assertions.api.android.content;
 
 import android.content.Intent;
 import org.fest.assertions.api.AbstractAssert;
+import org.fest.assertions.api.android.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION;
+import static android.content.Intent.FLAG_GRANT_WRITE_URI_PERMISSION;
+import static android.content.Intent.FLAG_DEBUG_LOG_RESOLUTION;
+import static android.content.Intent.FLAG_FROM_BACKGROUND;
+import static android.content.Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT;
+import static android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK;
+import static android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP;
+import static android.content.Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET;
+import static android.content.Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS;
+import static android.content.Intent.FLAG_ACTIVITY_FORWARD_RESULT;
+import static android.content.Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY;
+import static android.content.Intent.FLAG_ACTIVITY_MULTIPLE_TASK;
+import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
+import static android.content.Intent.FLAG_ACTIVITY_NO_ANIMATION;
+import static android.content.Intent.FLAG_ACTIVITY_NO_HISTORY;
+import static android.content.Intent.FLAG_RECEIVER_REGISTERED_ONLY;
+import static android.content.Intent.FLAG_ACTIVITY_NO_USER_ACTION;
+import static android.content.Intent.FLAG_ACTIVITY_PREVIOUS_IS_TOP;
+import static android.content.Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED;
+import static android.content.Intent.FLAG_ACTIVITY_REORDER_TO_FRONT;
+import static android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP;
+import static android.content.Intent.FLAG_ACTIVITY_TASK_ON_HOME;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -40,60 +67,81 @@ public class IntentAssert extends AbstractAssert<IntentAssert, Intent> {
   public IntentAssert hasFlags(int flags) {
     int expected = actual.getFlags();
     assertThat(expected)
-      .overridingErrorMessage("Expected <%s> but was <%s>.", flagToString(expected), flagToString(flags))
+      .overridingErrorMessage("Expected <%s> but was <%s>.", flagsToString(expected), flagsToString(flags))
       .isEqualTo(flags);
     return this;
   }
 
-  public static String flagToString(int flag) {
-    switch(flag) {
-      case Intent.FLAG_GRANT_READ_URI_PERMISSION:
-        return "grant_read_uri_permission";
-      case Intent.FLAG_GRANT_WRITE_URI_PERMISSION:
-        return "grant_write_uri_permission";
-      case Intent.FLAG_DEBUG_LOG_RESOLUTION:
-        return "debug_log_resolution";
-      case Intent.FLAG_FROM_BACKGROUND:
-        return "from_background";
-      case Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT:
-        return "activity_brought_to_front";
-      case Intent.FLAG_ACTIVITY_CLEAR_TASK:
-        return "activity_clear_task";
-      case Intent.FLAG_ACTIVITY_CLEAR_TOP:
-        return "activity_clear_top";
-      case Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET:
-        return "activity_clear_when_task_reset";
-      case Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS:
-        return "activity_exclude_from_recents";
-      case Intent.FLAG_ACTIVITY_FORWARD_RESULT:
-        return "activity_forward_result";
-      case Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY:
-        return "activity_launched_from_history";
-      case Intent.FLAG_ACTIVITY_MULTIPLE_TASK:
-        return "activity_multiple_task";
-      case Intent.FLAG_ACTIVITY_NEW_TASK:
-        return "activity_new_task";
-      case Intent.FLAG_ACTIVITY_NO_ANIMATION:
-        return "activity_no_animation";
-      case Intent.FLAG_ACTIVITY_NO_HISTORY:
-        return "activity_no_history";
-      case Intent.FLAG_ACTIVITY_NO_USER_ACTION:
-        return "activity_no_user_action";
-      case Intent.FLAG_ACTIVITY_PREVIOUS_IS_TOP:
-        return "activity_previous_is_top";
-      case Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED:
-        return "activity_reset_task_if_needed";
-      case Intent.FLAG_ACTIVITY_REORDER_TO_FRONT:
-        return "activity_reorder_to_front";
-      case Intent.FLAG_ACTIVITY_SINGLE_TOP:
-        return "activity_single_top";
-      case Intent.FLAG_ACTIVITY_TASK_ON_HOME:
-        return "activity_task_on_home";
-      //  case Intent.FLAG_RECEIVER_REGISTERED_ONLY:
-      //    return "receiver_registered_only";
-      default:
-        return flag + "";
+  public static String flagsToString(int flag) {
+    List<String> parts = new ArrayList<String>();
+
+    if ((flag & FLAG_GRANT_READ_URI_PERMISSION) != 0) {
+      parts.add("grant_read_uri_permission");
     }
+    if ((flag & FLAG_GRANT_WRITE_URI_PERMISSION) != 0) {
+      parts.add("grant_write_uri_permission");
+    }
+    if ((flag & FLAG_DEBUG_LOG_RESOLUTION) != 0) {
+      parts.add("debug_log_resolution");
+    }
+    if ((flag & FLAG_FROM_BACKGROUND) != 0) {
+      parts.add("from_background");
+    }
+    if ((flag & FLAG_ACTIVITY_BROUGHT_TO_FRONT) != 0) {
+      parts.add("activity_brought_to_front");
+    }
+    if ((flag & FLAG_ACTIVITY_CLEAR_TASK) != 0) {
+      parts.add("activity_clear_task");
+    }
+    if ((flag & FLAG_ACTIVITY_CLEAR_TOP) != 0) {
+      parts.add("activity_clear_top");
+    }
+    if ((flag & FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET) != 0) {
+      parts.add("activity_clear_when_task_reset");
+    }
+    if ((flag & FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS) != 0) {
+      parts.add("activity_exclude_from_recents");
+    }
+    if ((flag & FLAG_ACTIVITY_FORWARD_RESULT) != 0) {
+      parts.add("activity_forward_result");
+    }
+    if ((flag & FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) {
+      parts.add("activity_launched_from_history");
+    }
+    if ((flag & FLAG_ACTIVITY_MULTIPLE_TASK) != 0) {
+      parts.add("activity_multiple_task");
+    }
+    if ((flag & FLAG_ACTIVITY_NEW_TASK) != 0) {
+      parts.add("activity_new_task");
+    }
+    if ((flag & FLAG_ACTIVITY_NO_ANIMATION) != 0) {
+      parts.add("activity_no_animation");
+    }
+    if ((flag & FLAG_ACTIVITY_NO_HISTORY) != 0) {
+      parts.add("activity_no_history");
+    }
+    if ((flag & FLAG_RECEIVER_REGISTERED_ONLY) != 0) {
+      parts.add("receiver_registered_only");
+    }
+    if ((flag & FLAG_ACTIVITY_NO_USER_ACTION) != 0) {
+      parts.add("activity_no_user_action");
+    }
+    if ((flag & FLAG_ACTIVITY_PREVIOUS_IS_TOP) != 0) {
+      parts.add("activity_previous_is_top");
+    }
+    if ((flag & FLAG_ACTIVITY_RESET_TASK_IF_NEEDED) != 0) {
+      parts.add("activity_reset_task_if _needed");
+    }
+    if ((flag & FLAG_ACTIVITY_REORDER_TO_FRONT) != 0) {
+      parts.add("activity_reorder_to_front");
+    }
+    if ((flag & FLAG_ACTIVITY_SINGLE_TOP) != 0) {
+      parts.add("activity_single_top");
+    }
+    if ((flag & FLAG_ACTIVITY_TASK_ON_HOME) != 0) {
+      parts.add("activity_task_on_home");
+    }
+    return Utils.join(parts);
   }
 
 }


### PR DESCRIPTION
extension of #48

I'm not sure how to retrieve each flag from the intent, so the flagToString doesn't work for multiple flags (just returns the original int value). I've been trying to look into how the system does it but haven't found it yet.
