### PR TITLE
Change AbstractActivityAssert.hasRequestedOrientation() to public

### DIFF
--- a/src/main/java/org/fest/assertions/api/android/app/AbstractActivityAssert.java
+++ b/src/main/java/org/fest/assertions/api/android/app/AbstractActivityAssert.java
@@ -12,7 +12,7 @@ public abstract class AbstractActivityAssert<S extends AbstractActivityAssert<S,
     super(actual, selfType);
   }
 
-  protected S hasRequestedOrientation(int orientation) {
+  public S hasRequestedOrientation(int orientation) {
     isNotNull();
     int actualOrientation = actual.getRequestedOrientation();
     assertThat(actualOrientation) //


### PR DESCRIPTION
I think AbstractActivityAssert.hasRequestedOrientation() should be public method.
