### PR TITLE
changed ANDROID assertions to extend regular fest Assertions

### DIFF
--- a/generate-android-java.py
+++ b/generate-android-java.py
@@ -63,7 +63,7 @@ with open(OUTPUT, 'w') as out:
   out.write('// This class is generated. Do not modify directly!\n')
   out.write('package org.fest.assertions.api;\n\n')
   out.write('/** Assertions for testing Android classes. */\n')
-  out.write('public class ANDROID {')
+  out.write('public class ANDROID extends Assertions {')
   for package, target_package, generic_keys in sorted(assertions, key=lambda x: x[0]):
     out.write('\n')
     out.write('  public static %s%s assertThat(\n' % (generic_keys, package))

--- a/src/main/java/org/fest/assertions/api/ANDROID.java
+++ b/src/main/java/org/fest/assertions/api/ANDROID.java
@@ -4,7 +4,7 @@
 package org.fest.assertions.api;
 
 /** Assertions for testing Android classes. */
-public class ANDROID {
+public class ANDROID extends Assertions {
   public static org.fest.assertions.api.android.accounts.AccountAssert assertThat(
       android.accounts.Account actual) {
     return new org.fest.assertions.api.android.accounts.AccountAssert(actual);


### PR DESCRIPTION
In order to use fest assertions with fest-android assertions with one static import. Currently when using fest-android asserts in test class, you have to call `com.fest.assertions.api.Assertions.assertThat(...)` which not pretty. (IMO)
