### PR TITLE
Adding not null Assertion for IntentAssert

### DIFF
--- a/src/main/java/org/fest/assertions/api/android/content/IntentAssert.java
+++ b/src/main/java/org/fest/assertions/api/android/content/IntentAssert.java
@@ -85,6 +85,7 @@ public class IntentAssert extends AbstractAssert<IntentAssert, Intent> {
   public IntentAssert hasComponent(ComponentName expected) {
     ComponentName componentName = actual.getComponent();
     assertThat(componentName)
+        .isNotNull()
         .overridingErrorMessage("Expected component name <%s> but was <%s>.",
             expected.flattenToString(), componentName.flattenToString())
         .isEqualTo(expected);


### PR DESCRIPTION
During development of a deep linking feature for a client I ran into an issue where android-fest assertion was throwing a NullPointerException. This happens when you check for the component name in an IntentAssert but for some reason the ComponentName was not set (for whatever reason). This change adds a null check for component assertion as sometimes component can be null. 

Just an FYI - Since this repo is now gradle based, the Contributing markdown file seems to be out of date as it specifies `mvn clean verify` prior to pull request submission. :smile: 
