### PR TITLE
Use BluetoothGattCharacteristic write type as a value, not as a flag.

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/bluetooth/BluetoothGattCharacteristicAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/bluetooth/BluetoothGattCharacteristicAssert.java
@@ -27,6 +27,7 @@ import static android.bluetooth.BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPON
 import static android.bluetooth.BluetoothGattCharacteristic.WRITE_TYPE_SIGNED;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
 import static org.assertj.android.internal.IntegerUtils.buildBitMaskString;
+import static org.assertj.android.internal.IntegerUtils.buildNamedValueString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @TargetApi(JELLY_BEAN_MR2)
@@ -95,10 +96,10 @@ public class BluetoothGattCharacteristicAssert
   }
 
   public static String writeTypeToString(int writeType) {
-    return buildBitMaskString(writeType) //
-        .flag(WRITE_TYPE_DEFAULT, "default")
-        .flag(WRITE_TYPE_NO_RESPONSE, "no_response")
-        .flag(WRITE_TYPE_SIGNED, "signed")
+    return buildNamedValueString(writeType) //
+        .value(WRITE_TYPE_DEFAULT, "default")
+        .value(WRITE_TYPE_NO_RESPONSE, "no_response")
+        .value(WRITE_TYPE_SIGNED, "signed")
         .get();
   }
 


### PR DESCRIPTION
From the Javadoc:

> The write type to for this characteristic. Can be one of: WRITE_TYPE_DEFAULT, WRITE_TYPE_NO_RESPONSE or WRITE_TYPE_SIGNED.
