### PR TITLE
Fix hasFlags method in IntentAssert

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/internal/IntegerUtils.java
+++ b/assertj-android/src/main/java/org/assertj/android/internal/IntegerUtils.java
@@ -1,8 +1,8 @@
 package org.assertj.android.internal;
 
 import android.util.SparseArray;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.assertj.core.util.Strings;
 
 public final class IntegerUtils {
@@ -21,22 +21,19 @@ public final class IntegerUtils {
 
   public static final class BitMaskStringBuilder {
     private final int value;
-    private final Set<String> parts = new LinkedHashSet<>();
-    private int flags;
+    private final Map<Integer, String> parts = new LinkedHashMap<>();
 
     private BitMaskStringBuilder(int value) {
       this.value = value;
     }
 
     public BitMaskStringBuilder flag(int flag, String flagName) {
-      if ((flags & flag) != 0) {
-        throw new IllegalStateException(
-            "Duplicate flag detected: " + flagName + " with value " + Integer.toHexString(flag));
-      }
-      flags |= flag;
-
       if ((value & flag) != 0) {
-        parts.add(flagName);
+        if (parts.containsKey(flag)) {
+          parts.put(flag, parts.get(flag) + "|" + flagName);
+        } else {
+          parts.put(flag, flagName);
+        }
       }
       return this;
     }
@@ -45,7 +42,7 @@ public final class IntegerUtils {
       if (value == 0) {
         return "none";
       }
-      return Strings.join(parts).with(", ");
+      return Strings.join(parts.values()).with(", ");
     }
   }
 


### PR DESCRIPTION
Android has same values for flags `FLAG_ACTIVITY_MULTIPLE_TASK` and
`FLAG_RECEIVER_NO_ABORT`. Hence, any invocation of `hasFlags` resulted
in IllegalStateException being thrown.

Try, for example:

``` java
  @Test
  public void test() {
    assertThat(new Intent().addFlags(Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT))
        .hasFlags(Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT);
  }
```

I believe we also need a project with integration tests. Where this test could be written.
I personally created one to test your code from master branch. But I do not submit it here: it uses robolectric. Should I submit it?
I really do not know whether this change will break something in other place. The project definitely lacks tests IMHO...
