### PR TITLE
Fix for NumberPicker.getValue wrong assertion

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/widget/NumberPickerAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/widget/NumberPickerAssert.java
@@ -44,7 +44,7 @@ public class NumberPickerAssert
 
   public NumberPickerAssert hasValue(int value) {
     isNotNull();
-    int actualValue = actual.getMaxValue();
+    int actualValue = actual.getValue();
     assertThat(actualValue) //
         .overridingErrorMessage("Expected value <%s> but was <%s>.", value, actualValue) //
         .isEqualTo(value);


### PR DESCRIPTION
Discovered today wrong assert. Please accept
