### PR TITLE
Moved assertions from ListViewAssert to AbstractListViewAssert.

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/widget/AbstractListViewAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/widget/AbstractListViewAssert.java
@@ -6,6 +6,7 @@ import android.graphics.drawable.Drawable;
 import android.widget.ListView;
 
 import static android.os.Build.VERSION_CODES.GINGERBREAD;
+import static android.os.Build.VERSION_CODES.KITKAT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractListViewAssert<S extends AbstractListViewAssert<S, A>, A extends ListView>
@@ -68,6 +69,42 @@ public abstract class AbstractListViewAssert<S extends AbstractListViewAssert<S,
     assertThat(actualHeader) //
         .overridingErrorMessage("Expected overscroll header <%s> but was <%s>.", header, actualHeader) //
         .isSameAs(header);
+    return myself;
+  }
+
+  @TargetApi(KITKAT)
+  public S hasFooterDividersEnabled() {
+    isNotNull();
+    assertThat(actual.areFooterDividersEnabled()) //
+        .overridingErrorMessage("Expected to have footer dividers enabled but were not.") //
+        .isTrue();
+    return myself;
+  }
+
+  @TargetApi(KITKAT)
+  public S hasFooterDividersDisabled() {
+    isNotNull();
+    assertThat(actual.areFooterDividersEnabled()) //
+        .overridingErrorMessage("Expected to have footer dividers disabled but were not.") //
+        .isFalse();
+    return myself;
+  }
+
+  @TargetApi(KITKAT)
+  public S hasHeaderDividersEnabled() {
+    isNotNull();
+    assertThat(actual.areHeaderDividersEnabled()) //
+        .overridingErrorMessage("Expected to have header dividers enabled but were not.") //
+        .isTrue();
+    return myself;
+  }
+
+  @TargetApi(KITKAT)
+  public S hasHeaderDividersDisabled() {
+    isNotNull();
+    assertThat(actual.areHeaderDividersEnabled()) //
+        .overridingErrorMessage("Expected to have header dividers disabled but were not.") //
+        .isFalse();
     return myself;
   }
 }

--- a/assertj-android/src/main/java/org/assertj/android/api/widget/ListViewAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/widget/ListViewAssert.java
@@ -1,11 +1,7 @@
 // Copyright 2013 Square, Inc.
 package org.assertj.android.api.widget;
 
-import android.annotation.TargetApi;
 import android.widget.ListView;
-
-import static android.os.Build.VERSION_CODES.KITKAT;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Assertions for {@link ListView} instances.
@@ -15,41 +11,5 @@ import static org.assertj.core.api.Assertions.assertThat;
 public final class ListViewAssert extends AbstractListViewAssert<ListViewAssert, ListView> {
   public ListViewAssert(ListView actual) {
     super(actual, ListViewAssert.class);
-  }
-
-  @TargetApi(KITKAT)
-  public ListViewAssert hasFooterDividersEnabled() {
-    isNotNull();
-    assertThat(actual.areFooterDividersEnabled()) //
-        .overridingErrorMessage("Expected to have footer dividers enabled but were not.") //
-        .isTrue();
-    return this;
-  }
-
-  @TargetApi(KITKAT)
-  public ListViewAssert hasFooterDividersDisabled() {
-    isNotNull();
-    assertThat(actual.areFooterDividersEnabled()) //
-        .overridingErrorMessage("Expected to have footer dividers disabled but were not.") //
-        .isFalse();
-    return this;
-  }
-
-  @TargetApi(KITKAT)
-  public ListViewAssert hasHeaderDividersEnabled() {
-    isNotNull();
-    assertThat(actual.areHeaderDividersEnabled()) //
-        .overridingErrorMessage("Expected to have header dividers enabled but were not.") //
-        .isTrue();
-    return this;
-  }
-
-  @TargetApi(KITKAT)
-  public ListViewAssert hasHeaderDividersDisabled() {
-    isNotNull();
-    assertThat(actual.areHeaderDividersEnabled()) //
-        .overridingErrorMessage("Expected to have header dividers disabled but were not.") //
-        .isFalse();
-    return this;
   }
 }


### PR DESCRIPTION
I noticed this while working on another project: These assertions look like they were in the wrong place as they won't be inherited by subclasses like `ExpandableListViewAssert`. If they were there for a reason feel free to reject this PR (I'm curious to know what that reason might be though).