### PR TITLE
Fixing TabLayoutAssert.hasMode

### DIFF
--- a/assertj-android-design/src/main/java/org/assertj/android/design/api/widget/TabLayoutAssert.java
+++ b/assertj-android-design/src/main/java/org/assertj/android/design/api/widget/TabLayoutAssert.java
@@ -35,7 +35,7 @@ public class TabLayoutAssert extends
 
   public TabLayoutAssert hasTabMode(@TabMode int mode) {
     isNotNull();
-    int actualMode = actual.getTabCount();
+    int actualMode = actual.getTabMode();
     //noinspection ResourceType
     assertThat(actualMode) //
         .overridingErrorMessage("Expected tab mode of <%s> but was <%s>.", modeToString(mode),


### PR DESCRIPTION
Now it should properly retrieve tab mode instead of tab count. Fixes #171.