### PR TITLE
Add assertion for Intent extra value

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/content/IntentAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/content/IntentAssert.java
@@ -66,6 +66,15 @@ public class IntentAssert extends AbstractAssert<IntentAssert, Intent> {
     return this;
   }
 
+  public IntentAssert hasExtra(String name, Object expectedValue) {
+    hasExtra(name);
+    Object actualValue = this.actual.getExtras().get(name);
+    assertThat(actualValue)
+        .overridingErrorMessage("Expected extra <%s> to be <%s> but was <%s>.", name, expectedValue, actualValue)
+        .isEqualTo(expectedValue);
+    return this;
+  }
+
   public IntentAssert hasFlags(@IntentFlags int flags) {
     isNotNull();
     int actualFlags = actual.getFlags();


### PR DESCRIPTION
We can assert the existence of an extra on an Intent, but it is also handy to assert an expected value for an extra. This cleans up my activity tests quite nicely when ensuring that the correct values are passed between activities.

Note: I didn't see any tests; I am new to the project so if I am missing them please let me know and I will update with a test.