### PR TITLE
Google Maps asserts using wrong class in super constructor

### DIFF
--- a/assertj-android-play-services/src/main/java/org/assertj/android/playservices/api/maps/CameraPositionAssert.java
+++ b/assertj-android-play-services/src/main/java/org/assertj/android/playservices/api/maps/CameraPositionAssert.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CameraPositionAssert extends AbstractAssert<CameraPositionAssert, CameraPosition> {
   public CameraPositionAssert(CameraPosition actual) {
-    super(actual, CameraPosition.class);
+    super(actual, CameraPositionAssert.class);
   }
 
   public CameraPositionAssert hasBearing(float bearing) {

--- a/assertj-android-play-services/src/main/java/org/assertj/android/playservices/api/maps/GoogleMapAssert.java
+++ b/assertj-android-play-services/src/main/java/org/assertj/android/playservices/api/maps/GoogleMapAssert.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class GoogleMapAssert extends AbstractAssert<GoogleMapAssert, GoogleMap> {
   public GoogleMapAssert(GoogleMap actual) {
-    super(actual, GoogleMap.class);
+    super(actual, GoogleMapAssert.class);
   }
 
   public GoogleMapAssert hasMapType(int mapType) {

--- a/assertj-android-play-services/src/main/java/org/assertj/android/playservices/api/maps/MarkerAssert.java
+++ b/assertj-android-play-services/src/main/java/org/assertj/android/playservices/api/maps/MarkerAssert.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MarkerAssert extends AbstractAssert<MarkerAssert, Marker> {
   public MarkerAssert(Marker actual) {
-    super(actual, Marker.class);
+    super(actual, MarkerAssert.class);
   }
 
   public MarkerAssert hasAlpha(float alpha) {

--- a/assertj-android-play-services/src/main/java/org/assertj/android/playservices/api/maps/UiSettingsAssert.java
+++ b/assertj-android-play-services/src/main/java/org/assertj/android/playservices/api/maps/UiSettingsAssert.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class UiSettingsAssert extends AbstractAssert<UiSettingsAssert, UiSettings> {
   public UiSettingsAssert(UiSettings actual) {
-    super(actual, UiSettings.class);
+    super(actual, UiSettingsAssert.class);
   }
 
   public UiSettingsAssert hasCompassEnabled() {


### PR DESCRIPTION
Using Google Maps assertions caused a crash.

Example:

    java.lang.ClassCastException: Cannot cast org.assertj.android.playservices.api.maps.CameraPositionAssert to com.google.android.gms.maps.model.CameraPosition
        at java.lang.Class.cast(Class.java:3369)
        at org.assertj.core.api.AbstractAssert.<init>(AbstractAssert.java:63)
        at org.assertj.android.playservices.api.maps.CameraPositionAssert.<init>(CameraPositionAssert.java:11)
        at org.assertj.android.playservices.api.Assertions.assertThat(Assertions.java:26)
        ...