### PR TITLE
Fix hasDrawable by use of Bitmap

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/widget/ImageViewAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/widget/ImageViewAssert.java
@@ -2,11 +2,15 @@
 package org.assertj.android.api.widget;
 
 import android.annotation.TargetApi;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.widget.ImageView;
+
 import org.assertj.android.api.view.AbstractViewAssert;
 
 import static android.os.Build.VERSION_CODES.HONEYCOMB;
+import static android.os.Build.VERSION_CODES.HONEYCOMB_MR1;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,12 +55,17 @@ public class ImageViewAssert extends AbstractViewAssert<ImageViewAssert, ImageVi
     return this;
   }
 
+  @TargetApi(HONEYCOMB_MR1)
   public ImageViewAssert hasDrawable(Drawable drawable) {
     isNotNull();
+    Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
+
     Drawable actualDrawable = actual.getDrawable();
-    assertThat(actualDrawable) //
+    Bitmap actualBitmap = ((BitmapDrawable) actualDrawable).getBitmap();
+
+    assertThat(actualBitmap.sameAs(bitmap)) //
         .overridingErrorMessage("Expected drawable <%s> but was <%s>.", drawable, actualDrawable) //
-        .isSameAs(drawable);
+        .isTrue();
     return this;
   }
 


### PR DESCRIPTION
Thank you for this great library!


It's the following methods and passes the test.

```java
Drawable drawable = context.getResources().getDrawable(R.drawable.star);
testImageView.setImageDrawable(drawable);
assertThat(testImageView).hasDrawable(drawable);
```

However, the test does not pass to be the following method.

```xml
<ImageView
    android:id="@+id/test_image_view"
    android:src="@drawable/star"
    android:layout_width="wrap_content"
    android:layout_height="match_parent" />
```

```java
Drawable drawable = context.getResources().getDrawable(R.drawable.star);
assertThat(testImageView).hasDrawable(drawable);
```


So, I fixed hasDrawable by use of Bitmap.

Thank you.
