### PR TITLE
Fix bluetooth characteristic intdef copy-paste typo.

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/bluetooth/BluetoothGattCharacteristicPermissions.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/bluetooth/BluetoothGattCharacteristicPermissions.java
@@ -14,7 +14,7 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
         BluetoothGattCharacteristic.PERMISSION_READ_ENCRYPTED_MITM,
         BluetoothGattCharacteristic.PERMISSION_WRITE,
         BluetoothGattCharacteristic.PERMISSION_WRITE_ENCRYPTED,
-        BluetoothGattCharacteristic.PERMISSION_READ_ENCRYPTED_MITM,
+        BluetoothGattCharacteristic.PERMISSION_WRITE_ENCRYPTED_MITM,
         BluetoothGattCharacteristic.PERMISSION_WRITE_SIGNED,
         BluetoothGattCharacteristic.PERMISSION_WRITE_SIGNED_MITM
     }


### PR DESCRIPTION
PERMISSION_READ_ENCRYPTED_MITM was duplicated and
PERMISSION_WRITE_ENCRYPTED_MITM was missing.
Full list of available values:
https://developer.android.com/reference/android/bluetooth/BluetoothGattCharacteristic.html