### PR TITLE
PathAssert, not PaintAssert, fixes #191

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/graphics/PathAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/graphics/PathAssert.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Assertions for {@link Path} instances. */
 public class PathAssert extends AbstractAssert<PathAssert, Path> {
   public PathAssert(Path actual) {
-    super(actual, PaintAssert.class);
+    super(actual, PathAssert.class);
   }
 
   public PathAssert hasFillType(Path.FillType type) {


### PR DESCRIPTION
Fix #191.  

I don't have API 23 installed so I can't run the tests, but that's what CI servers are for, right?