### PR TITLE
Add query parameter and authority assertions to UriAssert

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/net/UriAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/net/UriAssert.java
@@ -4,24 +4,45 @@ import android.net.Uri;
 
 import org.assertj.core.api.AbstractAssert;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-public final class UriAssert extends AbstractAssert<UriAssert, Uri> {
+public final class UriAssert
+        extends AbstractAssert<UriAssert, Uri>
+        implements UriAssertions<UriAssert> {
 
     public UriAssert(Uri actual) {
         super(actual, UriAssert.class);
     }
 
+    /*
+     * NOTE: any methods added to this class should also be added to
+     * UriAssertions, and equivalent proxy methods added to
+     * UriQueryParamAssert.
+     */
+
+    @Override
     public UriAssert hasPath(String path) {
         isNotNull();
         String actualPath = actual.getPath();
         assertThat(actualPath) //
             .overridingErrorMessage("Expected path <%s> but was <%s>.", path, actualPath) //
             .isEqualTo(path);
+
         return this;
     }
 
+    /**
+     * @deprecated parameter was never used. Use {@link #hasNoPath()} instead.
+     */
+    @Deprecated
     public UriAssert hasNoPath(String action) {
+        return hasNoPath();
+    }
+
+    @Override
+    public UriAssert hasNoPath() {
         isNotNull();
         String actualPath = actual.getPath();
         assertThat(actualPath)
@@ -30,6 +51,7 @@ public final class UriAssert extends AbstractAssert<UriAssert, Uri> {
         return this;
     }
 
+    @Override
     public UriAssert hasPort(int port) {
         isNotNull();
         int actualPort = actual.getPort();
@@ -39,6 +61,7 @@ public final class UriAssert extends AbstractAssert<UriAssert, Uri> {
         return this;
     }
 
+    @Override
     public UriAssert hasHost(String host) {
         isNotNull();
         String actualHost = actual.getHost();
@@ -48,6 +71,7 @@ public final class UriAssert extends AbstractAssert<UriAssert, Uri> {
         return this;
     }
 
+    @Override
     public UriAssert hasFragment(String fragment) {
         isNotNull();
         String actualFragment = actual.getFragment();
@@ -57,6 +81,7 @@ public final class UriAssert extends AbstractAssert<UriAssert, Uri> {
         return this;
     }
 
+    @Override
     public UriAssert hasNoFragment() {
         isNotNull();
         String actualFragment = actual.getFragment();
@@ -66,6 +91,7 @@ public final class UriAssert extends AbstractAssert<UriAssert, Uri> {
         return this;
     }
 
+    @Override
     public UriAssert hasQuery(String query) {
         isNotNull();
         String actualQuery = actual.getQuery();
@@ -75,6 +101,7 @@ public final class UriAssert extends AbstractAssert<UriAssert, Uri> {
         return this;
     }
 
+    @Override
     public UriAssert hasNoQuery() {
         isNotNull();
         String actualQuery = actual.getQuery();
@@ -84,6 +111,7 @@ public final class UriAssert extends AbstractAssert<UriAssert, Uri> {
         return this;
     }
 
+    @Override
     public UriAssert hasScheme(String scheme) {
         isNotNull();
         String actualScheme = actual.getScheme();
@@ -93,6 +121,7 @@ public final class UriAssert extends AbstractAssert<UriAssert, Uri> {
         return this;
     }
 
+    @Override
     public UriAssert hasUserInfo(String userInfo) {
         isNotNull();
         String actualUserInfo = actual.getUserInfo();
@@ -102,6 +131,7 @@ public final class UriAssert extends AbstractAssert<UriAssert, Uri> {
         return this;
     }
 
+    @Override
     public UriAssert hasNoUserInfo() {
         isNotNull();
         String actualUserInfo = actual.getUserInfo();
@@ -111,4 +141,40 @@ public final class UriAssert extends AbstractAssert<UriAssert, Uri> {
         return this;
     }
 
+    @Override
+    public UriAssert hasAuthority(String authority) {
+        isNotNull();
+        String actualAuthority = actual.getAuthority();
+        assertThat(actualAuthority)
+                .overridingErrorMessage("Expected authority <%s> but was <%s>",
+                        authority,
+                        actualAuthority)
+                .isEqualTo(authority);
+        return this;
+    }
+
+    @Override
+    public UriAssert hasQueryParameters(String... params) {
+        isNotNull();
+
+        for (String param : params) {
+            assertThat(actual.getQueryParameter(param))
+                    .overridingErrorMessage("Expected query parameter <%s> to be defined",
+                            param)
+                    .isNotNull();
+        }
+        return this;
+    }
+
+    @Override
+    public UriQueryParamAssert hasQueryParameter(String param) {
+        isNotNull();
+
+        List<String> actualValues = actual.getQueryParameters(param);
+        assertThat(actualValues)
+                .overridingErrorMessage("Expected query parameter <%s> to be defined", param)
+                .isNotEmpty();
+
+        return new UriQueryParamAssert(this, actual, param, actualValues);
+    }
 }

--- a/assertj-android/src/main/java/org/assertj/android/api/net/UriAssertions.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/net/UriAssertions.java
@@ -1,0 +1,22 @@
+package org.assertj.android.api.net;
+
+/**
+ * All assertions supported on Uri values by {@link UriAssert}. The interface exists
+ * to ensure that {@link UriQueryParamAssert} maintains a full set of proxy methods.
+ */
+public interface UriAssertions<T extends UriAssertions> {
+    T hasPath(String path);
+    T hasNoPath();
+    T hasPort(int port);
+    T hasHost(String host);
+    T hasFragment(String fragment);
+    T hasNoFragment();
+    T hasQuery(String query);
+    T hasNoQuery();
+    T hasScheme(String scheme);
+    T hasUserInfo(String userInfo);
+    T hasNoUserInfo();
+    T hasAuthority(String authority);
+    T hasQueryParameters(String... params);
+    UriQueryParamAssert hasQueryParameter(String param);
+}

--- a/assertj-android/src/main/java/org/assertj/android/api/net/UriQueryParamAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/net/UriQueryParamAssert.java
@@ -1,0 +1,162 @@
+package org.assertj.android.api.net;
+
+import android.net.Uri;
+
+import org.assertj.core.api.AbstractAssert;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Wrapper of {@link UriAssert} that adds methods assert a property (once)
+ * on the value of a query parameter, without disrupting the normal usage
+ * of UriAssert. For example:
+ *
+ * <code>
+ *     assertThat(uri)
+ *         .hasQueryParameter("user").withValue("bob@example.com")
+ *         .hasQueryParameter("married")
+ *         .hasQueryParameter("pets").withValues("Spot", "Daisy");
+ * </code>
+ *
+ * The interface specifically does not allow multiple asserts on the value, so that it
+ * to avoid confusion about where the assertions on the value end and the the assertions
+ * on the URI resume. For example:
+ *
+ * <code>
+ *     assertThat(uri)
+ *         .hasQueryParameter("dog")
+ *             .withValue("dachshund")
+ *             .withValue("labrador") // INVALID - method is no longer available
+ *         .hasQueryParameter("cat")
+ * </code>
+ *
+ * @see UriAssert#hasQueryParameter(String)
+ */
+public final class UriQueryParamAssert
+        extends AbstractAssert<UriQueryParamAssert, Uri>
+        implements UriAssertions {
+
+    private final UriAssert parent;
+    private final String paramName;
+    private final List<String> actualValues;
+
+    public UriQueryParamAssert(
+            UriAssert parent,
+            Uri actualUri,
+            String paramName,
+            List<String> actualValues) {
+        super(actualUri, UriQueryParamAssert.class);
+        this.parent = parent;
+        this.paramName = paramName;
+        this.actualValues = actualValues;
+    }
+
+    public UriAssert withValue(String value) {
+        assertThat(actualValues)
+                .overridingErrorMessage(
+                        "Expected query parameter <%s> to have single value <%s>, "
+                                + "but has multiple values: <%s>",
+                        paramName,
+                        value,
+                        actualValues)
+                .hasSize(1);
+
+        assertThat(actualValues)
+                .overridingErrorMessage(
+                        "Expected query parameter <%s> to have value <%s>, but was <%s>",
+                        paramName, value, actualValues.get(0))
+                .isEqualTo(value);
+        return parent;
+    }
+
+    public UriAssert withValues(String... values) {
+        // use TreeSets for consistent ordering
+        Set<String> actualValuesSet = new TreeSet<>(actualValues);
+        Set<String> valuesSet = new TreeSet<>(Arrays.asList(values));
+        assertThat(valuesSet)
+                .overridingErrorMessage(
+                        "Expected query parameter <%s> to have values <%s>, but was <%s>",
+                        paramName,
+                        valuesSet,
+                        actualValuesSet)
+                .isEqualTo(valuesSet);
+        return parent;
+    }
+
+    // all other methods are proxies to the parent
+
+    @Override
+    public UriAssert hasPath(String path) {
+        return parent.hasPath(path);
+    }
+
+    @Override
+    public UriAssert hasNoPath() {
+        return parent.hasNoPath();
+    }
+
+    @Override
+    public UriAssert hasPort(int port) {
+        return parent.hasPort(port);
+    }
+
+    @Override
+    public UriAssert hasHost(String host) {
+        return parent.hasHost(host);
+    }
+
+    @Override
+    public UriAssert hasFragment(String fragment) {
+        return parent.hasFragment(fragment);
+    }
+
+    @Override
+    public UriAssert hasNoFragment() {
+        return parent.hasNoFragment();
+    }
+
+    @Override
+    public UriAssert hasQuery(String query) {
+        return parent.hasQuery(query);
+    }
+
+    @Override
+    public UriAssert hasNoQuery() {
+        return parent.hasNoQuery();
+    }
+
+    @Override
+    public UriAssert hasScheme(String scheme) {
+        return parent.hasScheme(scheme);
+    }
+
+    @Override
+    public UriAssert hasUserInfo(String userInfo) {
+        return parent.hasUserInfo(userInfo);
+    }
+
+    @Override
+    public UriAssert hasNoUserInfo() {
+        return parent.hasNoUserInfo();
+    }
+
+    @Override
+    public UriAssert hasAuthority(String authority) {
+        return parent.hasAuthority(authority);
+    }
+
+    @Override
+    public UriQueryParamAssert hasQueryParameter(String param) {
+        return parent.hasQueryParameter(param);
+    }
+
+    @Override
+    public UriAssert hasQueryParameters(String... params) {
+        return parent.hasQueryParameters(params);
+    }
+}


### PR DESCRIPTION
There's some fancy footwork in this CL to allow fluent assertions about parameter values; I don't know if there is precedent for this elsewhere, or if it is frowned upon. For example, with this patch you can write:

``` java
assertThat(uri)
    .hasQueryParameter("user").withValue("bob@example.com")
    .hasQueryParameter("married")
    .hasQueryParameter("pets").withValues("Spot", "Daisy");
```

Whereas more conventionally I think you would have to write:

``` java
assertThat(uri).hasQueryParameter("user");
assertThat(uri.getQueryParameter("user")).isEqualTo("bob@example.com");
assertThat(uri.getQueryParameters("pets")).contains("Spot", "Daisy");
```

If you don't think the "withValue" extra fluent method is valuable, I can take that out, but personally I prefer it.
