### PR TITLE
Invert BluetoothClassAssert#doesNotHave(int) assertion

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/bluetooth/BluetoothClassAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/bluetooth/BluetoothClassAssert.java
@@ -46,7 +46,7 @@ public class BluetoothClassAssert extends AbstractAssert<BluetoothClassAssert, B
     assertThat(actual.hasService(service)) //
         .overridingErrorMessage("Expected to not have service <%s> but did.",
             serviceToString(service)) //
-        .isTrue();
+        .isFalse();
     return this;
   }
 


### PR DESCRIPTION
The method is the negative condition of `#hasService(int)` but the assertion wasn't inverted.