### PR TITLE
Assert against the real value in BluetoothGattCharacteristicAssert#hasUuid()

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/bluetooth/BluetoothGattCharacteristicAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/bluetooth/BluetoothGattCharacteristicAssert.java
@@ -71,7 +71,7 @@ public class BluetoothGattCharacteristicAssert
   public BluetoothGattCharacteristicAssert hasUuid(UUID uuid) {
     isNotNull();
     UUID actualUuid = actual.getUuid();
-    assertThat(uuid) //
+    assertThat(actualUuid) //
         .overridingErrorMessage("Expected UUID <%s> but was <%s>.", uuid, actualUuid) //
         .isEqualTo(uuid);
     return this;


### PR DESCRIPTION
The assertion was comparing the provided value against the provided value. It now compares the actual value against the provided.