### PR TITLE
Assert against the real value in BluetoothGattDescriptorAssert#hasUuid()

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/bluetooth/BluetoothGattDescriptorAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/bluetooth/BluetoothGattDescriptorAssert.java
@@ -39,7 +39,7 @@ public class BluetoothGattDescriptorAssert
   public BluetoothGattDescriptorAssert hasUuid(UUID uuid) {
     isNotNull();
     UUID actualUuid = actual.getUuid();
-    assertThat(uuid) //
+    assertThat(actualUuid) //
         .overridingErrorMessage("Expected UUID <%s> but was <%s>.", uuid, actualUuid) //
         .isEqualTo(uuid);
     return this;


### PR DESCRIPTION
The assertion was comparing the provided value against the provided value.
It now compares the actual value against the provided.