### PR TITLE
Compare against expected value in DisplayAssert#hasDisplayId()

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/view/DisplayAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/view/DisplayAssert.java
@@ -55,7 +55,7 @@ public class DisplayAssert extends AbstractAssert<DisplayAssert, Display> {
     int actualId = actual.getDisplayId();
     assertThat(actualId) //
         .overridingErrorMessage("Expected ID <%s> but was <%s>", id, actualId) //
-        .isEqualTo(actualId);
+        .isEqualTo(id);
     return this;
   }
 


### PR DESCRIPTION
Previously the actual value was being compared against itself.