### PR TITLE
Various fixes in AbstractAnimationAssert

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/view/animation/AbstractAnimationAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/view/animation/AbstractAnimationAssert.java
@@ -116,7 +116,7 @@ public abstract class AbstractAnimationAssert<S extends AbstractAnimationAssert<
     long actualTime = actual.getStartTime();
     assertThat(actualTime) //
         .overridingErrorMessage("Expected start time <%s> but was <%s>.", time, actualTime) //
-        .isEqualTo(actualTime);
+        .isEqualTo(time);
     return myself;
   }
 
@@ -213,7 +213,7 @@ public abstract class AbstractAnimationAssert<S extends AbstractAnimationAssert<
   public S isChangingTransformationMatrix() {
     isNotNull();
     assertThat(actual.willChangeTransformationMatrix()) //
-        .overridingErrorMessage("Expected to be changing bounds but was not.") //
+        .overridingErrorMessage("Expected to be changing transformation matrix but was not.") //
         .isTrue();
     return myself;
   }
@@ -221,7 +221,7 @@ public abstract class AbstractAnimationAssert<S extends AbstractAnimationAssert<
   public S isNotChangingTransformationMatrix() {
     isNotNull();
     assertThat(actual.willChangeTransformationMatrix()) //
-        .overridingErrorMessage("Expected to not be changing bounds but was.") //
+        .overridingErrorMessage("Expected to not be changing transformation matrix but was.") //
         .isFalse();
     return myself;
   }


### PR DESCRIPTION
- Correct a set of error messages for Animation#willChangeTransformationMatrix
- Compare against the expected value rather than the actual value for AbstractAnimationAssert#hasStartTime()