### PR TITLE
Adjust error message in AbstractAccessibilityRecordAssert

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/view/accessibility/AbstractAccessibilityRecordAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/view/accessibility/AbstractAccessibilityRecordAssert.java
@@ -127,7 +127,7 @@ public abstract class AbstractAccessibilityRecordAssert<S extends AbstractAccess
     isNotNull();
     int actualScroll = actual.getScrollY();
     assertThat(actualScroll) //
-        .overridingErrorMessage("Expected maximum Y scroll <%s> but was <%s>.", scroll,
+        .overridingErrorMessage("Expected Y scroll <%s> but was <%s>.", scroll,
             actualScroll) //
         .isEqualTo(scroll);
     return this;


### PR DESCRIPTION
The error message for AbstractAccessibilityRecordAssert#hasScrollY()
was indicating the maximum Y scroll rather than the actual, but was
using the actual.