### PR TITLE
Compare against expected value in ToastAssert#hasGravity(int)

### DIFF
--- a/assertj-android/src/main/java/org/assertj/android/api/widget/ToastAssert.java
+++ b/assertj-android/src/main/java/org/assertj/android/api/widget/ToastAssert.java
@@ -27,7 +27,7 @@ public class ToastAssert extends AbstractAssert<ToastAssert, Toast> {
     int actualGravity = actual.getGravity();
     assertThat(actualGravity) //
         .overridingErrorMessage("Expected gravity <%s> but was <%s>.", gravity, actualGravity) //
-        .isEqualTo(actualGravity);
+        .isEqualTo(gravity);
     return this;
   }
 


### PR DESCRIPTION
`ToastAssert#hasGravity(int)` was comparing against the real value instead of
the expected value.