### PR TITLE
Compare against expected value in RecyclerViewLayoutManagerAssert

### DIFF
--- a/assertj-android-recyclerview-v7/src/main/java/org/assertj/android/recyclerview/v7/api/widget/RecyclerViewLayoutManagerAssert.java
+++ b/assertj-android-recyclerview-v7/src/main/java/org/assertj/android/recyclerview/v7/api/widget/RecyclerViewLayoutManagerAssert.java
@@ -220,7 +220,7 @@ public class RecyclerViewLayoutManagerAssert
     int actualWidth = actual.getMinimumWidth();
     assertThat(actualWidth) //
         .overridingErrorMessage("Expected minimum width <%s> but was <%s>.", width, actualWidth) //
-        .isEqualTo(actualWidth);
+        .isEqualTo(width);
     return this;
   }
 
@@ -230,7 +230,7 @@ public class RecyclerViewLayoutManagerAssert
     assertThat(actualHeight) //
         .overridingErrorMessage("Expected minimum height <%s> but was <%s>.", height,
             actualHeight) //
-        .isEqualTo(actualHeight);
+        .isEqualTo(height);
     return this;
   }
 }


### PR DESCRIPTION
`RecyclerViewLayoutManagerAssert#hasMinimumHeight(int)` and `RecyclerViewLayoutManager#hasMinimumWidth(int)`
were comparing against the real value rather than the expected.